### PR TITLE
Fixing randomization option

### DIFF
--- a/DnD_Battler.py
+++ b/DnD_Battler.py
@@ -986,7 +986,8 @@ class Encounter():
             return [joe for joe in folk if joe.condition == 'normal']
 
         def _random(folk):
-            return random.shuffle(folk)
+            randomized = random.shuffle(folk)
+            return randomized
 
         def _weakest(folk):
             return sorted(folk, key=lambda query: query.hp)


### PR DESCRIPTION
Randomization was broken, as the `random.shuffle` method will shuffle the array in place without returning the original array.  Seems like an oversight with the `random` package, but it broke for me in Python 3.4.3 nonetheless. 
