### PR TITLE
Fixed a bug in average roll calculation

### DIFF
--- a/DnD.py
+++ b/DnD.py
@@ -127,17 +127,13 @@ class Dice:
         :param verbose:
         :return:
         """
-        result = self.bonus
-        for d in self.dice:
-            if self.avg:  # NPC rolls
-                if self.crit:
-                    result += d
-                else:
-                    result += round(d / 2 + 1)
-            else:
-                for x in range(0, self.crit + 1): result += random.randint(1, d)
-        self.crit = 0
-        return result
+        if self.avg: # NPC rolls
+            result = math.floor(sum(d/2+0.5 for d in self.dice))
+        else:
+            result = sum(random.randint(1,d) for d in self.dice)
+        if self.crit:
+            result *= 2;
+        return result+self.bonus
 
     def icosaroll(self, verbose=0):
         """


### PR DESCRIPTION
The way you're calculating the average dice roll doesn't match the WotC way. The issue is twofold, actually. 

1) For single dice rolls, you're taking the ceiling of the average rather than the floor (well, technically you're rounding it, but this will always result in an x.5 value, so it's effectively a ceiling). This means that  for instance for a 1d4 you calculate the average damage as round(4/2+1) = 3. If you compare this with a Camel (MM pg 320), the stated average for a 1d4 attack is 2. This leads to monsters/NPCs doing _slightly_ more damage on average than they should.

2) For multiple dice rolls, you're rounding too soon, which also results in monsters doing more damage than they should. For example, consider the Tarrasque's bite attack (4d12+10). The stated average for this in the MM is 36, but using your approach you get 38. This is because you're basically doing round(12/6+1)*4, rather than floor((12/6+1)*4).